### PR TITLE
Feature make rollingHash promise optional

### DIFF
--- a/dist/cjs/index.d.ts
+++ b/dist/cjs/index.d.ts
@@ -1,7 +1,7 @@
 interface Options<T> {
-    hashFunction: (string: string) => Promise<T>;
+    hashFunction: (string: string) => Promise<T> | T;
     toBase64Function: (hash: T) => string;
     toHexFunction: (hash: T) => string;
 }
-declare function rollingHash<T>(message: string, { hashFunction, toBase64Function, toHexFunction }: Options<T>): Promise<string>;
+declare function rollingHash<T>(message: string, { hashFunction, toBase64Function, toHexFunction }: Options<T>): string | Promise<string>;
 export default rollingHash;

--- a/dist/cjs/index.d.ts
+++ b/dist/cjs/index.d.ts
@@ -1,5 +1,5 @@
 interface Options<T> {
-    hashFunction: (string: string) => Promise<T> | T;
+    hashFunction: (message: string) => Promise<T> | T;
     toBase64Function: (hash: T) => string;
     toHexFunction: (hash: T) => string;
 }

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -31,12 +31,10 @@ function rollingHash(message, { hashFunction, toBase64Function, toHexFunction })
     if (hashFunction.constructor.name === "AsyncFunction") {
         return promiseWrapper(message, { hashFunction, toBase64Function, toHexFunction });
     }
-    else {
-        const hashedMessage = hashFunction(message);
-        const [first] = toBase64Function(hashedMessage);
-        const salt = getRollingSalt(first);
-        const rolledHash = hashFunction(message + salt);
-        return toHexFunction(rolledHash);
-    }
+    const hashedMessage = hashFunction(message);
+    const [first] = toBase64Function(hashedMessage);
+    const salt = getRollingSalt(first);
+    const rolledHash = hashFunction(message + salt);
+    return toHexFunction(rolledHash);
 }
 exports.default = rollingHash;

--- a/dist/cjs/index.js
+++ b/dist/cjs/index.js
@@ -12,7 +12,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const BASE64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 function getRollingSalt(saltKey) {
     const date = new Date();
-    // Find the offset (0-63) (this will always be the same for a user email)
+    // Find the offset (0-63) (this will be the same for any identical saltKey)
     const dateOffset = BASE64.indexOf(saltKey);
     const rollingDate = new Date(date.setDate(date.getDate() - dateOffset));
     return `${rollingDate.getFullYear()}${Math.floor(rollingDate.getMonth() / 2)}`;

--- a/dist/mjs/index.d.ts
+++ b/dist/mjs/index.d.ts
@@ -1,7 +1,7 @@
 interface Options<T> {
-    hashFunction: (string: string) => Promise<T>;
+    hashFunction: (string: string) => Promise<T> | T;
     toBase64Function: (hash: T) => string;
     toHexFunction: (hash: T) => string;
 }
-declare function rollingHash<T>(message: string, { hashFunction, toBase64Function, toHexFunction }: Options<T>): Promise<string>;
+declare function rollingHash<T>(message: string, { hashFunction, toBase64Function, toHexFunction }: Options<T>): string | Promise<string>;
 export default rollingHash;

--- a/dist/mjs/index.d.ts
+++ b/dist/mjs/index.d.ts
@@ -1,5 +1,5 @@
 interface Options<T> {
-    hashFunction: (string: string) => Promise<T> | T;
+    hashFunction: (message: string) => Promise<T> | T;
     toBase64Function: (hash: T) => string;
     toHexFunction: (hash: T) => string;
 }

--- a/dist/mjs/index.js
+++ b/dist/mjs/index.js
@@ -1,7 +1,7 @@
 const BASE64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 function getRollingSalt(saltKey) {
     const date = new Date();
-    // Find the offset (0-63) (this will always be the same for a user email)
+    // Find the offset (0-63) (this will be the same for any identical saltKey)
     const dateOffset = BASE64.indexOf(saltKey);
     const rollingDate = new Date(date.setDate(date.getDate() - dateOffset));
     return `${rollingDate.getFullYear()}${Math.floor(rollingDate.getMonth() / 2)}`;

--- a/dist/mjs/index.js
+++ b/dist/mjs/index.js
@@ -6,11 +6,24 @@ function getRollingSalt(saltKey) {
     const rollingDate = new Date(date.setDate(date.getDate() - dateOffset));
     return `${rollingDate.getFullYear()}${Math.floor(rollingDate.getMonth() / 2)}`;
 }
-async function rollingHash(message, { hashFunction, toBase64Function, toHexFunction }) {
+async function promiseWrapper(message, { hashFunction, toBase64Function, toHexFunction }) {
     const hashedMessage = await hashFunction(message);
     const [first] = toBase64Function(hashedMessage);
     const salt = getRollingSalt(first);
     const rolledHash = await hashFunction(message + salt);
     return toHexFunction(rolledHash);
+}
+function rollingHash(message, { hashFunction, toBase64Function, toHexFunction }) {
+    // to make this either an async operation or a sync operation we check if the given function is async
+    if (hashFunction.constructor.name === "AsyncFunction") {
+        return promiseWrapper(message, { hashFunction, toBase64Function, toHexFunction });
+    }
+    else {
+        const hashedMessage = hashFunction(message);
+        const [first] = toBase64Function(hashedMessage);
+        const salt = getRollingSalt(first);
+        const rolledHash = hashFunction(message + salt);
+        return toHexFunction(rolledHash);
+    }
 }
 export default rollingHash;

--- a/dist/mjs/index.js
+++ b/dist/mjs/index.js
@@ -18,12 +18,10 @@ function rollingHash(message, { hashFunction, toBase64Function, toHexFunction })
     if (hashFunction.constructor.name === "AsyncFunction") {
         return promiseWrapper(message, { hashFunction, toBase64Function, toHexFunction });
     }
-    else {
-        const hashedMessage = hashFunction(message);
-        const [first] = toBase64Function(hashedMessage);
-        const salt = getRollingSalt(first);
-        const rolledHash = hashFunction(message + salt);
-        return toHexFunction(rolledHash);
-    }
+    const hashedMessage = hashFunction(message);
+    const [first] = toBase64Function(hashedMessage);
+    const salt = getRollingSalt(first);
+    const rolledHash = hashFunction(message + salt);
+    return toHexFunction(rolledHash);
 }
 export default rollingHash;

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 interface Options<T> {
-  hashFunction: (string: string) => Promise<T> | T;
+  hashFunction: (message: string) => Promise<T> | T;
   toBase64Function: (hash: T) => string;
   toHexFunction: (hash: T) => string;
 }
@@ -29,21 +29,20 @@ async function promiseWrapper<T>(message: string, { hashFunction, toBase64Functi
 }
 
 function rollingHash<T>(message: string, { hashFunction, toBase64Function, toHexFunction }: Options<T>) {
-
   // to make this either an async operation or a sync operation we check if the given function is async
   if (hashFunction.constructor.name === "AsyncFunction") {
     return promiseWrapper(message, { hashFunction, toBase64Function, toHexFunction })
-  } else {
-    const hashedMessage = hashFunction(message);
-
-    const [first] = toBase64Function(hashedMessage as T);
-
-    const salt = getRollingSalt(first);
-
-    const rolledHash = hashFunction(message + salt);
-
-    return toHexFunction(rolledHash as T);
   }
+
+  const hashedMessage = hashFunction(message);
+
+  const [first] = toBase64Function(hashedMessage as T);
+
+  const salt = getRollingSalt(first);
+
+  const rolledHash = hashFunction(message + salt);
+
+  return toHexFunction(rolledHash as T);
 }
 
 

--- a/index.ts
+++ b/index.ts
@@ -8,7 +8,7 @@ const BASE64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/
 
 function getRollingSalt(saltKey: string): string {
   const date = new Date();
-  // Find the offset (0-63) (this will always be the same for a user email)
+  // Find the offset (0-63) (this will be the same for any identical saltKey)
   const dateOffset = BASE64.indexOf(saltKey);
 
   const rollingDate = new Date(date.setDate(date.getDate() - dateOffset));

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,10 @@ This rolling hash library is supposed to be able to work with all kinds of encry
 
 The code is simple to use with any crypto Library.
 
-Simply input the given hashFunction, toBase64Function and toHexFunction and retrieve a rolledHash
+Simply input the given hashFunction, toBase64Function and toHexFunction and retrieve a rolledHash.
 
-example:
+example with an async crypto library:
+
 ```javascript
 import rollingHash from "rolling-hash";
 import crypto from "node:crypto";
@@ -37,7 +38,30 @@ function toHexFunction(hash) {
   return hash.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
-const rolledHash = await rollingHash("foobar", { hashFunction, toBase64Function, toHexFunction })
+const rolledHash = await rollingHash("foobar", { hashFunction, toBase64Function, toHexFunction });
+
+// use rolledHash as you want
+```
+
+example with a sync crypto library:
+
+```javascript
+import rollingHash from "rolling-hash";
+import cryptoJs from "crypto-js";
+
+function hashFunction(str) {
+  return cryptoJs.SHA256(str);
+}
+
+function toBase64Function(hash) {
+  return hash.toString(cryptoJs.enc.Base64);
+}
+
+function toHexFunction(hash) {
+  return hash.toString(cryptoJs.enc.Hex);
+}
+
+const rolledHash = rollingHash("foobar", { hashFunction, toBase64Function, toHexFunction });
 
 // use rolledHash as you want
 ```

--- a/test/rolling-hash-feature.js
+++ b/test/rolling-hash-feature.js
@@ -82,8 +82,8 @@ describe("Rolling hash with CryptoJs", () => {
     return hash.toString(cryptoJs.enc.Hex);
   }
 
-  it("Validating rolling hash is hex encoded", async () => {
-    const ppid = await rollingHash("foo-bar", { hashFunction, toBase64Function, toHexFunction });
+  it("Validating rolling hash is hex encoded", () => {
+    const ppid = rollingHash("foo-bar", { hashFunction, toBase64Function, toHexFunction });
 
     assert.match(ppid, /[0-9A-Fa-f]{6}/g, "The encrypted id is not hex encoded");
   });
@@ -146,7 +146,7 @@ describe("Rolling hash for crypto-js and node:crypto at the same time", () => {
 
   it("we should get the same value from both rolling hash functions", async () => {
     const ppid1 = await rollingHash("foobar", { hashFunction: nodehashFunction, toBase64Function: nodetoBase64Function, toHexFunction: nodetoHexFunction });
-    const ppid2 = await rollingHash("foobar", { hashFunction: cryptoJshashFunction, toBase64Function: cryptoJstoBase64Function, toHexFunction: cryptoJstoHexFunction });
+    const ppid2 = rollingHash("foobar", { hashFunction: cryptoJshashFunction, toBase64Function: cryptoJstoBase64Function, toHexFunction: cryptoJstoHexFunction });
 
     assert.equal(ppid1, ppid2);
   });

--- a/test/rolling-hash-feature.js
+++ b/test/rolling-hash-feature.js
@@ -13,7 +13,7 @@ class MockDate extends Date {
   }
 }
 
-describe("Rolling hash with node:crypto", () => {
+describe("Rolling hash with node:crypto async", () => {
   beforeEach(() => {
     customDate = "2022-01-01T00:00:00.000Z";
     // eslint-disable-next-line no-undef
@@ -63,7 +63,7 @@ describe("Rolling hash with node:crypto", () => {
   });
 });
 
-describe("Rolling hash with CryptoJs", () => {
+describe("Rolling hash with CryptoJs sync", () => {
   beforeEach(() => {
     customDate = "2022-01-01T00:00:00.000Z";
     // eslint-disable-next-line no-undef


### PR DESCRIPTION
We've gotten a request to make the package Promise optional, so this is a P.O.C on how it can look when supporting both Async hashes and not. It should still work the same no matter what you use if you use a supported hashing library